### PR TITLE
fix: resolve Azure.ResourceManager downgrade

### DIFF
--- a/src/App/AzureKvSslExpirationChecker.csproj
+++ b/src/App/AzureKvSslExpirationChecker.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.11.0" />
-    <PackageReference Include="Azure.ResourceManager" Version="1.9.0" />
+    <PackageReference Include="Azure.ResourceManager" Version="1.12.0" />
     <PackageReference Include="Azure.ResourceManager.KeyVault" Version="1.3.0" />
     <PackageReference Include="Azure.Security.KeyVault.Certificates" Version="4.5.0" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.0" />


### PR DESCRIPTION
## Summary
- upgrade Azure.ResourceManager package to 1.12.0 to satisfy KeyVault dependency

## Testing
- `dotnet restore ./src/App/AzureKvSslExpirationChecker.csproj` *(fails: Could not resolve SDK 'Microsoft.NET.Sdk.WindowsDesktop')*


------
https://chatgpt.com/codex/tasks/task_e_6896c042a6bc8328b4d09348e60f1d0d