### PR TITLE
Fix unsupported Spacing attribute in MainWindow

### DIFF
--- a/src/App/Views/MainWindow.xaml
+++ b/src/App/Views/MainWindow.xaml
@@ -63,9 +63,9 @@
             </DataGrid.Columns>
         </DataGrid>
 
-        <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" Spacing="10">
-            <Button Content="Start Scan" Command="{Binding StartScanAsyncCommand}" IsEnabled="{Binding CanStart}"/>
-            <Button Content="Cancel" Command="{Binding CancelCommand}" IsEnabled="{Binding IsScanning}"/>
+        <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right">
+            <Button Content="Start Scan" Command="{Binding StartScanAsyncCommand}" IsEnabled="{Binding CanStart}" Margin="0,0,10,0"/>
+            <Button Content="Cancel" Command="{Binding CancelCommand}" IsEnabled="{Binding IsScanning}" Margin="0,0,10,0"/>
             <Button Content="Open Output Folder" Command="{Binding OpenOutputFolderCommand}"/>
         </StackPanel>
     </Grid>


### PR DESCRIPTION
## Summary
- replace unsupported `StackPanel` Spacing property with per-button margins

## Testing
- `dotnet restore src/App/AzureKvSslExpirationChecker.csproj -p:EnableWindowsTargeting=true`
- `dotnet publish src/App/AzureKvSslExpirationChecker.csproj -c Release -r win-x64 --self-contained true /p:PublishSingleFile=true /p:IncludeAllContentForSelfExtract=true /p:EnableCompressionInSingleFile=true -p:EnableWindowsTargeting=true` *(fails: ResourceIdentifier not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896c2fd6ce08328a3b1fddb73444af6