### PR TITLE
Resolve Azure SDK package downgrade warning

### DIFF
--- a/src/App/AzureKvSslExpirationChecker.csproj
+++ b/src/App/AzureKvSslExpirationChecker.csproj
@@ -12,7 +12,7 @@
     <PublishTrimmed>false</PublishTrimmed>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.11.0" />
+    <PackageReference Include="Azure.Identity" Version="1.14.2" />
     <PackageReference Include="Azure.ResourceManager" Version="1.12.0" />
     <PackageReference Include="Azure.ResourceManager.KeyVault" Version="1.3.0" />
     <PackageReference Include="Azure.Security.KeyVault.Certificates" Version="4.5.0" />

--- a/src/App/Services/AzureScanService.cs
+++ b/src/App/Services/AzureScanService.cs
@@ -4,9 +4,11 @@ using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure;
+using Azure.Core;
 using Azure.Identity;
 using Azure.ResourceManager;
 using Azure.ResourceManager.KeyVault;
+using Azure.ResourceManager.Resources;
 using Azure.Security.KeyVault.Certificates;
 using AzureKvSslExpirationChecker.Models;
 
@@ -47,7 +49,7 @@ namespace AzureKvSslExpirationChecker.Services
             var vaults = new List<KeyVaultResource>();
             await RetryPolicy.RunAsync(async () =>
             {
-                await foreach (var v in subscription.GetKeyVaults().GetAllAsync(cancellationToken: ct))
+                await foreach (var v in subscription.GetKeyVaultsAsync(cancellationToken: ct))
                 {
                     vaults.Add(v);
                 }
@@ -57,7 +59,7 @@ namespace AzureKvSslExpirationChecker.Services
             {
                 ct.ThrowIfCancellationRequested();
                 log.Report($"Scanning vault {vault.Data.Name}...");
-                var certClient = new CertificateClient(new Uri(vault.Data.Properties.VaultUri!), credential);
+                var certClient = new CertificateClient(vault.Data.Properties.VaultUri!, credential);
 
                 await RetryPolicy.RunAsync(async () =>
                 {
@@ -67,7 +69,7 @@ namespace AzureKvSslExpirationChecker.Services
                         var record = new CertificateRecord
                         {
                             VaultName = vault.Data.Name,
-                            VaultUri = vault.Data.Properties.VaultUri!,
+                            VaultUri = vault.Data.Properties.VaultUri!.ToString(),
                             CertificateName = prop.Name,
                             Version = prop.Version,
                             Enabled = prop.Enabled,


### PR DESCRIPTION
## Summary
- update Azure SDK packages to satisfy KeyVault dependencies and fix vulnerability warning
- adapt AzureScanService to new Azure.ResourceManager API

## Testing
- `dotnet restore src/App/AzureKvSslExpirationChecker.csproj -p:EnableWindowsTargeting=true`
- `dotnet build src/App/AzureKvSslExpirationChecker.csproj -p:EnableWindowsTargeting=true`
- `dotnet test src/AzureKvSslExpirationChecker.sln -p:EnableWindowsTargeting=true`


------
https://chatgpt.com/codex/tasks/task_e_68980c8146dc8328aff8b8ed3346cc6c