### PR TITLE
Package Windows build in folder for releases

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -22,13 +22,14 @@ jobs:
       - name: Restore
         run: dotnet restore ./src/App/AzureKvSslExpirationChecker.csproj
 
-      - name: Publish (Self-contained single-file)
-        run: dotnet publish ./src/App/AzureKvSslExpirationChecker.csproj -c Release -r win-x64 --self-contained true /p:PublishSingleFile=true /p:IncludeAllContentForSelfExtract=true /p:EnableCompressionInSingleFile=true
+      - name: Publish (Self-contained)
+        run: dotnet publish ./src/App/AzureKvSslExpirationChecker.csproj -c Release -r win-x64 --self-contained true
 
       - name: Create ZIP
         run: |
-          cd ./src/App/bin/Release/net8.0-windows/win-x64/publish
-          powershell -command "Compress-Archive -Path * -DestinationPath ${{ github.workspace }}\AzureKvSslExpirationChecker_win-x64.zip"
+          cd ./src/App/bin/Release/net8.0-windows/win-x64
+          Rename-Item publish AzureKvSslExpirationChecker
+          Compress-Archive -Path AzureKvSslExpirationChecker -DestinationPath ${{ github.workspace }}\AzureKvSslExpirationChecker_win-x64.zip
 
       - name: Generate timestamp
         id: date

--- a/README.md
+++ b/README.md
@@ -59,14 +59,14 @@ my-vault             www.contoso.com                         1234567890abcdef   
 dotnet restore ./src/App/AzureKvSslExpirationChecker.csproj
 dotnet build ./src/App/AzureKvSslExpirationChecker.csproj
 ```
-To publish a portable executable:
+To publish a portable folder:
 ```bash
-dotnet publish ./src/App/AzureKvSslExpirationChecker.csproj -c Release -r win-x64 --self-contained true /p:PublishSingleFile=true /p:IncludeAllContentForSelfExtract=true /p:EnableCompressionInSingleFile=true
+dotnet publish ./src/App/AzureKvSslExpirationChecker.csproj -c Release -r win-x64 --self-contained true
 ```
-The output can be zipped as `AzureKvSslExpirationChecker_win-x64.zip`.
+Rename the publish output folder as desired and zip it (e.g., `AzureKvSslExpirationChecker_win-x64.zip`).
 
 ## CI Workflow
-Pushes to branches matching `feature/*` trigger a GitHub Action that builds the project, publishes a self-contained executable, and creates a GitHub Release with the zipped artifact.
+Pushes to branches matching `feature/*` trigger a GitHub Action that builds the project, publishes a self-contained folder, and creates a GitHub Release with the zipped artifact.
 
 ## License
 MIT


### PR DESCRIPTION
## Summary
- publish Windows app as a self-contained folder rather than single EXE
- zip the publish folder and upload it to releases

## Testing
- `dotnet restore ./src/App/AzureKvSslExpirationChecker.csproj -p:EnableWindowsTargeting=true`
- `dotnet build ./src/App/AzureKvSslExpirationChecker.csproj -p:EnableWindowsTargeting=true`

------
https://chatgpt.com/codex/tasks/task_e_689810ff8d0c8328a36245ecb2b04145