### PR TITLE
Add logging and startup error reporting

### DIFF
--- a/src/App/App.xaml.cs
+++ b/src/App/App.xaml.cs
@@ -1,11 +1,56 @@
+using System;
+using System.Threading.Tasks;
 using System.Windows;
+using System.Windows.Threading;
+using AzureKvSslExpirationChecker.Services;
 
 namespace AzureKvSslExpirationChecker
 {
     /// <summary>
     /// Interaction logic for App.
+    /// Initializes logging and global exception handlers.
     /// </summary>
     public partial class App : Application
     {
+        /// <summary>
+        /// Configure logging and exception handlers when the application starts.
+        /// </summary>
+        /// <param name="e">Startup event args.</param>
+        protected override void OnStartup(StartupEventArgs e)
+        {
+            base.OnStartup(e);
+
+            Logger.Log("Application starting");
+
+            // Global exception handlers
+            DispatcherUnhandledException += OnDispatcherUnhandledException;
+            AppDomain.CurrentDomain.UnhandledException += OnUnhandledException;
+            TaskScheduler.UnobservedTaskException += OnUnobservedTaskException;
+        }
+
+        private static void OnDispatcherUnhandledException(object sender, DispatcherUnhandledExceptionEventArgs e)
+        {
+            Logger.Log("Unhandled UI exception", e.Exception);
+            MessageBox.Show($"An unexpected error occurred. See log at {Logger.LogPath}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+            e.Handled = true;
+        }
+
+        private static void OnUnhandledException(object? sender, UnhandledExceptionEventArgs e)
+        {
+            if (e.ExceptionObject is Exception ex)
+            {
+                Logger.Log("Unhandled domain exception", ex);
+            }
+            else
+            {
+                Logger.Log($"Unhandled domain exception: {e.ExceptionObject}");
+            }
+        }
+
+        private static void OnUnobservedTaskException(object? sender, UnobservedTaskExceptionEventArgs e)
+        {
+            Logger.Log("Unobserved task exception", e.Exception);
+            e.SetObserved();
+        }
     }
 }

--- a/src/App/Services/Logger.cs
+++ b/src/App/Services/Logger.cs
@@ -1,0 +1,38 @@
+using System;
+using System.IO;
+
+namespace AzureKvSslExpirationChecker.Services
+{
+    /// <summary>
+    /// Simple file logger for the application.
+    /// </summary>
+    internal static class Logger
+    {
+        private static readonly object _lock = new();
+        private static readonly string _logPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "AzureKvSslExpirationChecker.log");
+
+        /// <summary>Full path to the log file.</summary>
+        public static string LogPath => _logPath;
+
+        /// <summary>Append a message to the log file with a timestamp.</summary>
+        public static void Log(string message)
+        {
+            try
+            {
+                var line = $"{DateTime.Now:yyyy-MM-dd HH:mm:ss} {message}{Environment.NewLine}";
+                lock (_lock)
+                {
+                    File.AppendAllText(_logPath, line);
+                }
+            }
+            catch
+            {
+                // Never throw from the logger
+            }
+        }
+
+        /// <summary>Append a message and exception details to the log file.</summary>
+        public static void Log(string message, Exception ex) =>
+            Log($"{message}: {ex}");
+    }
+}

--- a/src/App/ViewModels/MainViewModel.cs
+++ b/src/App/ViewModels/MainViewModel.cs
@@ -125,9 +125,11 @@ namespace AzureKvSslExpirationChecker.ViewModels
             ProgressText = string.Empty;
             SummaryText = string.Empty;
             _cts = new CancellationTokenSource();
+            Logger.Log("Scan started");
             var progress = new Progress<string>(msg =>
             {
                 Logs.Add(msg);
+                Logger.Log(msg);
                 ProgressText = msg;
             });
 
@@ -148,18 +150,22 @@ namespace AzureKvSslExpirationChecker.ViewModels
                 var reportPath = await _reportWriter.WriteTxtAsync(result, SubscriptionId, ThresholdDays, OutputFolder, _cts.Token).ConfigureAwait(false);
                 SummaryText = $"Vaults: {result.VaultCount}  Certificates: {result.CertificateCount}  Warnings: {result.WarningCount}  Duration: {result.Duration}";
                 Logs.Add($"Report saved to {reportPath}");
+                Logger.Log($"Report saved to {reportPath}");
             }
             catch (OperationCanceledException)
             {
                 Logs.Add("Scan canceled.");
+                Logger.Log("Scan canceled.");
             }
             catch (Exception ex)
             {
                 Logs.Add($"Error: {ex.Message}");
+                Logger.Log("Error", ex);
                 System.Windows.MessageBox.Show("An error occurred. See log for details.", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
             }
             finally
             {
+                Logger.Log("Scan finished");
                 IsScanning = false;
             }
         }


### PR DESCRIPTION
## Summary
- add simple file logger and capture errors during startup
- log scan progress and errors to a log file for easier debugging

## Testing
- `dotnet build src/App/AzureKvSslExpirationChecker.csproj -c Release` *(fails: Could not resolve SDK "Microsoft.NET.Sdk.WindowsDesktop")*

------
https://chatgpt.com/codex/tasks/task_e_689814105df88328ad0be73d2a4181d6