### PR TITLE
Fix password binding and enable nullable

### DIFF
--- a/src/App/AzureKvSslExpirationChecker.csproj
+++ b/src/App/AzureKvSslExpirationChecker.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net8.0-windows</TargetFramework>
@@ -10,6 +10,7 @@
     <IncludeAllContentForSelfExtract>true</IncludeAllContentForSelfExtract>
     <EnableCompressionInSingleFile>true</EnableCompressionInSingleFile>
     <PublishTrimmed>false</PublishTrimmed>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.14.2" />

--- a/src/App/Helpers/PasswordBoxHelper.cs
+++ b/src/App/Helpers/PasswordBoxHelper.cs
@@ -1,0 +1,87 @@
+using System.Windows;
+using System.Windows.Controls;
+
+namespace AzureKvSslExpirationChecker.Helpers
+{
+    /// <summary>
+    /// Allows binding the <see cref="PasswordBox.Password"/> property.
+    /// </summary>
+    public static class PasswordBoxHelper
+    {
+        public static readonly DependencyProperty BoundPasswordProperty =
+            DependencyProperty.RegisterAttached(
+                "BoundPassword",
+                typeof(string),
+                typeof(PasswordBoxHelper),
+                new PropertyMetadata(string.Empty, OnBoundPasswordChanged));
+
+        public static readonly DependencyProperty BindPasswordProperty =
+            DependencyProperty.RegisterAttached(
+                "BindPassword",
+                typeof(bool),
+                typeof(PasswordBoxHelper),
+                new PropertyMetadata(false, OnBindPasswordChanged));
+
+        private static readonly DependencyProperty IsUpdatingProperty =
+            DependencyProperty.RegisterAttached(
+                "IsUpdating",
+                typeof(bool),
+                typeof(PasswordBoxHelper),
+                new PropertyMetadata(false));
+
+        public static string? GetBoundPassword(DependencyObject d)
+            => (string?)d.GetValue(BoundPasswordProperty);
+
+        public static void SetBoundPassword(DependencyObject d, string? value)
+            => d.SetValue(BoundPasswordProperty, value);
+
+        public static bool GetBindPassword(DependencyObject d)
+            => (bool)d.GetValue(BindPasswordProperty);
+
+        public static void SetBindPassword(DependencyObject d, bool value)
+            => d.SetValue(BindPasswordProperty, value);
+
+        private static bool GetIsUpdating(DependencyObject d)
+            => (bool)d.GetValue(IsUpdatingProperty);
+
+        private static void SetIsUpdating(DependencyObject d, bool value)
+            => d.SetValue(IsUpdatingProperty, value);
+
+        private static void OnBoundPasswordChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is PasswordBox box && !GetIsUpdating(box))
+            {
+                box.Password = e.NewValue as string ?? string.Empty;
+            }
+        }
+
+        private static void OnBindPasswordChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is PasswordBox box)
+            {
+                bool wasBound = (bool)e.OldValue;
+                bool needBound = (bool)e.NewValue;
+
+                if (wasBound)
+                {
+                    box.PasswordChanged -= HandlePasswordChanged;
+                }
+
+                if (needBound)
+                {
+                    box.PasswordChanged += HandlePasswordChanged;
+                }
+            }
+        }
+
+        private static void HandlePasswordChanged(object sender, RoutedEventArgs e)
+        {
+            if (sender is PasswordBox box)
+            {
+                SetIsUpdating(box, true);
+                SetBoundPassword(box, box.Password);
+                SetIsUpdating(box, false);
+            }
+        }
+    }
+}

--- a/src/App/Views/MainWindow.xaml
+++ b/src/App/Views/MainWindow.xaml
@@ -4,6 +4,7 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:vm="clr-namespace:AzureKvSslExpirationChecker.ViewModels"
+        xmlns:helpers="clr-namespace:AzureKvSslExpirationChecker.Helpers"
         mc:Ignorable="d"
         Title="Azure KV SSL Expiration Checker" Height="600" Width="900">
     <Window.DataContext>
@@ -32,7 +33,8 @@
                 </StackPanel>
                 <StackPanel Width="200" Margin="0,0,10,0">
                     <TextBlock Text="Client Secret"/>
-                    <PasswordBox Password="{Binding ClientSecret, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                    <PasswordBox helpers:PasswordBoxHelper.BindPassword="True"
+                                 helpers:PasswordBoxHelper.BoundPassword="{Binding ClientSecret, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
                 </StackPanel>
                 <StackPanel Width="120" Margin="0,0,10,0">
                     <TextBlock Text="Warning Days"/>


### PR DESCRIPTION
## Summary
- allow binding to PasswordBox via attached helper
- switch to Microsoft.NET.Sdk and enable nullable context

## Testing
- `dotnet build App/AzureKvSslExpirationChecker.csproj -c Release -p:EnableWindowsTargeting=true`


------
https://chatgpt.com/codex/tasks/task_e_6898174cf848832893f82e9463a1b071