### PR TITLE
Fix brush resources in WPF styles

### DIFF
--- a/src/App/Styles/Colors.xaml
+++ b/src/App/Styles/Colors.xaml
@@ -3,4 +3,9 @@
     <Color x:Key="PrimaryColor">#0078D4</Color>
     <Color x:Key="BackgroundColor">#FF1E1E1E</Color>
     <Color x:Key="ForegroundColor">#FFFFFFFF</Color>
+
+    <!-- Brushes derived from the base colors -->
+    <SolidColorBrush x:Key="PrimaryBrush" Color="{StaticResource PrimaryColor}" />
+    <SolidColorBrush x:Key="BackgroundBrush" Color="{StaticResource BackgroundColor}" />
+    <SolidColorBrush x:Key="ForegroundBrush" Color="{StaticResource ForegroundColor}" />
 </ResourceDictionary>

--- a/src/App/Styles/Styles.xaml
+++ b/src/App/Styles/Styles.xaml
@@ -3,8 +3,8 @@
     <Style x:Key="BaseButtonStyle" TargetType="Button">
         <Setter Property="Margin" Value="5"/>
         <Setter Property="Padding" Value="8,4"/>
-        <Setter Property="Background" Value="{StaticResource PrimaryColor}"/>
-        <Setter Property="Foreground" Value="{StaticResource ForegroundColor}"/>
+        <Setter Property="Background" Value="{StaticResource PrimaryBrush}"/>
+        <Setter Property="Foreground" Value="{StaticResource ForegroundBrush}"/>
     </Style>
     <Style TargetType="TextBox">
         <Setter Property="Margin" Value="0,0,0,5"/>


### PR DESCRIPTION
## Summary
- define SolidColorBrush resources derived from existing colors
- update button style to use brush resources instead of color values

## Testing
- `dotnet build src/AzureKvSslExpirationChecker.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68981ba5036c832883c1c1907093f900