### PR TITLE
Wire Start Scan button and add live logging

### DIFF
--- a/src/App/Views/MainWindow.xaml
+++ b/src/App/Views/MainWindow.xaml
@@ -52,22 +52,29 @@
             <TextBlock Text="{Binding ProgressText}" Margin="0,5,0,0"/>
         </StackPanel>
 
-        <DataGrid Grid.Row="1" ItemsSource="{Binding Records}" AutoGenerateColumns="False" CanUserAddRows="False" Margin="0,0,0,10">
-            <DataGrid.Columns>
-                <DataGridTextColumn Header="Vault" Binding="{Binding VaultName}" Width="*"/>
-                <DataGridTextColumn Header="Certificate" Binding="{Binding CertificateName}" Width="2*"/>
-                <DataGridTextColumn Header="Version" Binding="{Binding Version}" Width="*"/>
-                <DataGridCheckBoxColumn Header="Enabled" Binding="{Binding Enabled}" Width="*"/>
-                <DataGridTextColumn Header="NotBefore" Binding="{Binding NotBefore}" Width="*"/>
-                <DataGridTextColumn Header="ExpiresOn" Binding="{Binding ExpiresOn}" Width="*"/>
-                <DataGridTextColumn Header="Days" Binding="{Binding DaysUntilExpiry}" Width="*"/>
-                <DataGridTextColumn Header="Warning" Binding="{Binding IsWarning}" Width="*"/>
-            </DataGrid.Columns>
-        </DataGrid>
+        <Grid Grid.Row="1" Margin="0,0,0,10">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="*"/>
+                <RowDefinition Height="120"/>
+            </Grid.RowDefinitions>
+            <DataGrid Grid.Row="0" ItemsSource="{Binding Records}" AutoGenerateColumns="False" CanUserAddRows="False">
+                <DataGrid.Columns>
+                    <DataGridTextColumn Header="Vault" Binding="{Binding VaultName}" Width="*"/>
+                    <DataGridTextColumn Header="Certificate" Binding="{Binding CertificateName}" Width="2*"/>
+                    <DataGridTextColumn Header="Version" Binding="{Binding Version}" Width="*"/>
+                    <DataGridCheckBoxColumn Header="Enabled" Binding="{Binding Enabled}" Width="*"/>
+                    <DataGridTextColumn Header="NotBefore" Binding="{Binding NotBefore}" Width="*"/>
+                    <DataGridTextColumn Header="ExpiresOn" Binding="{Binding ExpiresOn}" Width="*"/>
+                    <DataGridTextColumn Header="Days" Binding="{Binding DaysUntilExpiry}" Width="*"/>
+                    <DataGridTextColumn Header="Warning" Binding="{Binding IsWarning}" Width="*"/>
+                </DataGrid.Columns>
+            </DataGrid>
+            <RichTextBox x:Name="rtbLog" Grid.Row="1" Margin="0,10,0,0" IsReadOnly="True"/>
+        </Grid>
 
         <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right">
-            <Button Content="Start Scan" Command="{Binding StartScanAsyncCommand}" IsEnabled="{Binding CanStart}" Margin="0,0,10,0"/>
-            <Button Content="Cancel" Command="{Binding CancelCommand}" IsEnabled="{Binding IsScanning}" Margin="0,0,10,0"/>
+            <Button x:Name="btnStartScan" Content="Start Scan" Margin="0,0,10,0"/>
+            <Button x:Name="btnCancel" Content="Cancel" IsEnabled="False" Margin="0,0,10,0"/>
             <Button Content="Open Output Folder" Command="{Binding OpenOutputFolderCommand}"/>
         </StackPanel>
     </Grid>

--- a/src/App/Views/MainWindow.xaml.cs
+++ b/src/App/Views/MainWindow.xaml.cs
@@ -1,4 +1,13 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using System.Windows;
+using Azure;
+using Azure.Identity;
+using AzureKvSslExpirationChecker.Models;
+using AzureKvSslExpirationChecker.Services;
+using AzureKvSslExpirationChecker.ViewModels;
 
 namespace AzureKvSslExpirationChecker.Views
 {
@@ -7,9 +16,101 @@ namespace AzureKvSslExpirationChecker.Views
     /// </summary>
     public partial class MainWindow : Window
     {
+        private CancellationTokenSource? _cts;
+        private readonly AzureScanService _scanService;
+
         public MainWindow()
         {
             InitializeComponent();
+            btnStartScan.Click += btnStartScan_Click;
+            btnCancel.Click += btnCancel_Click;
+            _scanService = new AzureScanService(new AzureAuthFactory());
+        }
+
+        private void AppendLog(string message)
+        {
+            string line = $"[{DateTime.UtcNow:HH:mm:ss}] {message}";
+            if (rtbLog.Dispatcher.CheckAccess())
+            {
+                rtbLog.AppendText(line + Environment.NewLine);
+                rtbLog.ScrollToEnd();
+            }
+            else
+            {
+                rtbLog.Dispatcher.BeginInvoke(new Action(() =>
+                {
+                    rtbLog.AppendText(line + Environment.NewLine);
+                    rtbLog.ScrollToEnd();
+                }));
+            }
+        }
+
+        private async void btnStartScan_Click(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                btnStartScan.IsEnabled = false;
+                btnCancel.IsEnabled = true;
+                var vm = (MainViewModel)DataContext;
+                vm.Records.Clear();
+                rtbLog.Document.Blocks.Clear();
+                _cts = new CancellationTokenSource();
+
+                string subscriptionId = vm.SubscriptionId?.Trim();
+                string tenantId = vm.TenantId?.Trim();
+                string clientId = vm.ClientId?.Trim();
+                string clientSecret = vm.ClientSecret;
+                string outputFolder = vm.OutputFolder?.Trim();
+                int warningDays = vm.ThresholdDays;
+
+                if (string.IsNullOrWhiteSpace(subscriptionId) ||
+                    string.IsNullOrWhiteSpace(tenantId) ||
+                    string.IsNullOrWhiteSpace(clientId) ||
+                    string.IsNullOrWhiteSpace(clientSecret) ||
+                    string.IsNullOrWhiteSpace(outputFolder))
+                {
+                    AppendLog("Faltan datos obligatorios (Subscription/Tenant/Client/Secret/Output).");
+                    return;
+                }
+
+                Directory.CreateDirectory(outputFolder);
+
+                AppendLog("Iniciando autenticación…");
+                var cred = new ClientSecretCredential(tenantId, clientId, clientSecret);
+                AppendLog("Autenticado OK.");
+
+                var progress = new Progress<string>(msg => AppendLog(msg));
+
+                await _scanService.ScanAsync(subscriptionId, tenantId, clientId, clientSecret, warningDays, progress, _cts.Token, record =>
+                {
+                    Dispatcher.BeginInvoke(new Action(() => vm.Records.Add(record)));
+                });
+
+                AppendLog("Scan finalizado.");
+            }
+            catch (RequestFailedException ex)
+            {
+                AppendLog($"Error Azure ({ex.Status}/{ex.ErrorCode}): {ex.Message}");
+            }
+            catch (OperationCanceledException)
+            {
+                AppendLog("Operación cancelada por el usuario.");
+            }
+            catch (Exception ex)
+            {
+                AppendLog($"Error inesperado: {ex.Message}");
+            }
+            finally
+            {
+                btnStartScan.IsEnabled = true;
+                btnCancel.IsEnabled = false;
+            }
+        }
+
+        private void btnCancel_Click(object sender, RoutedEventArgs e)
+        {
+            _cts?.Cancel();
+            AppendLog("Cancelando…");
         }
     }
 }


### PR DESCRIPTION
## Summary
- hook up Start Scan and Cancel buttons to async handlers
- stream scan progress to a RichTextBox log and certificate grid
- extend scan service with per-record callback and detailed progress messages

## Testing
- `dotnet build src/AzureKvSslExpirationChecker.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_689913a5d4808328b356f7534d93a2d4